### PR TITLE
add error when graphql integer variable can't be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - template files are loaded once at the start and then cached with their front-matter (see [issue 87](https://github.com/KNowledgeOnWebScale/walder/issues/87))
+- error when integer in graphql query variable can't be parsed
 
 ### Fixed
 - html-convertor can't convert a template using a layout that in turn extends another layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - template files are loaded once at the start and then cached with their front-matter (see [issue 87](https://github.com/KNowledgeOnWebScale/walder/issues/87))
-- error when integer in graphql query variable can't be parsed
+- error when integer in graphql query variable can't be parsed (see [issue 84](https://github.com/KNowledgeOnWebScale/walder/issues/84))
 
 ### Fixed
 - html-convertor can't convert a template using a layout that in turn extends another layout

--- a/lib/handlers/graphql-ld-handler.js
+++ b/lib/handlers/graphql-ld-handler.js
@@ -155,7 +155,7 @@ module.exports = class GraphQLLDHandler extends Handler {
         if (definedParameters[key].type === 'integer') {
           const intVal = parseInt(val);
           if (isNaN(intVal)) {
-            const err = new Error(`Could not parse integer ${val}`);
+            const err = new Error(`Could not parse integer "${val}" for variable $${key}`);
             err.type = 'GRAPHQL-INTEGERPARSEERROR';
             throw err;
           }

--- a/lib/handlers/graphql-ld-handler.js
+++ b/lib/handlers/graphql-ld-handler.js
@@ -152,9 +152,13 @@ module.exports = class GraphQLLDHandler extends Handler {
       let newQuery = query;
       keys.forEach(key => {
         let val = variables[key];
-
         if (definedParameters[key].type === 'integer') {
-          val = parseInt(val);
+          const intVal = parseInt(val);
+          if (isNaN(intVal)) {
+            const err = new Error(`Could not parse integer ${val}`);
+            err.type = 'GRAPHQL-INTEGERPARSEERROR';
+            throw err;
+          }
         } else {
           val = `"${val}"`;
         }

--- a/lib/handlers/graphql-ld-handler.js
+++ b/lib/handlers/graphql-ld-handler.js
@@ -159,6 +159,7 @@ module.exports = class GraphQLLDHandler extends Handler {
             err.type = 'GRAPHQL-INTEGERPARSEERROR';
             throw err;
           }
+          val = intVal;
         } else {
           val = `"${val}"`;
         }

--- a/test/handlers/graphql-ld-handler.js
+++ b/test/handlers/graphql-ld-handler.js
@@ -1,4 +1,5 @@
 require('chai').should();
+const expect = require('chai').expect;
 const GraphQLLDHandler = require('../../lib/handlers/graphql-ld-handler');
 
 describe('GraphQLLDHandler', function () {
@@ -17,11 +18,27 @@ describe('GraphQLLDHandler', function () {
         "in": "path"
       }
     };
-    const expectedNewQuery = '{ id @single name @single review @single { rating(value: 1) }}';
     const actualNewQuery = handler._substituteVariables(query, variables, definedParameters);
-
-    actualNewQuery.should.eql(expectedNewQuery);
   });
+
+  it('should be able to throw an error when an integer can\'t be parsed', () => {
+    const handler = new GraphQLLDHandler();
+    const query = '{ id @single name @single review @single { rating(value: $value) }}';
+    const variables = {
+      "value": "b"
+    };
+    const definedParameters = {
+      "value": {
+        "required": true,
+        "type": "integer",
+        "description": "Rating of the tv shows.",
+        "in": "path"
+      }
+    };
+
+    expect(() => handler._substituteVariables(query, variables, definedParameters)).to.throw();
+  });
+
 
   it('string variable in query', () => {
     const handler = new GraphQLLDHandler();

--- a/test/handlers/graphql-ld-handler.js
+++ b/test/handlers/graphql-ld-handler.js
@@ -18,7 +18,9 @@ describe('GraphQLLDHandler', function () {
         "in": "path"
       }
     };
+    const expectedNewQuery = '{ id @single name @single review @single { rating(value: 1) }}';
     const actualNewQuery = handler._substituteVariables(query, variables, definedParameters);
+    actualNewQuery.should.eql(expectedNewQuery);
   });
 
   it('should be able to throw an error when an integer can\'t be parsed', () => {


### PR DESCRIPTION
This adds an error when a graphql integer variable can not be parsed to an integer. As requested in #84 